### PR TITLE
Raw view 

### DIFF
--- a/frontend/src/app/shared/components/viewer/viewer.component.css
+++ b/frontend/src/app/shared/components/viewer/viewer.component.css
@@ -36,6 +36,7 @@
 
 .content {
   height: 100%;
+  width: 100%;
   padding: 10px;
   word-break: break-word;
   overflow-y: scroll;
@@ -54,4 +55,8 @@
 
 .test-container{
   border: 1px solid red;
+}
+
+pre{
+    white-space:pre-wrap;
 }

--- a/frontend/src/app/shared/components/viewer/viewer.component.html
+++ b/frontend/src/app/shared/components/viewer/viewer.component.html
@@ -28,13 +28,13 @@
             </div>
           </div>
         </ng-template>
-        
+
         <app-accordion [title]="'Components'">
           <div body class="component-container">
             <ng-container *ngTemplateOutlet="components; context:{ $implicit: data }"></ng-container>
           </div>
-        </app-accordion>      
-  
+        </app-accordion>
+
         <ng-template #metadata let-data>
           <ng-container *ngFor="let item of data | keyvalue; let first = first">
             <ng-container *ngIf="!first">
@@ -51,8 +51,8 @@
             </ng-container>
           </ng-container>
         </ng-template>
-        
-  
+
+
         <app-accordion [title]="'Metadata'">
           <div body class="component-container">
             <ng-container *ngTemplateOutlet="metadata; context:{ $implicit: data }"></ng-container>
@@ -60,11 +60,11 @@
         </app-accordion>
       </ng-container>
     </div>
-    
+
     <ng-container *ngIf="!pretty">
-      <div class="content">
+      <pre class="content">
         {{routing.data ? dataHandler.GetSBOMInfo(routing.data).contents : ''}}
-      </div>
+      </pre>
     </ng-container>
   </div>
 </div>


### PR DESCRIPTION
- Raw view now displays similarly to the file contents 
<img width="974" alt="Screenshot 2023-07-14 at 4 07 41 PM" src="https://github.com/SoftwareDesignLab/svip-ui/assets/56976587/1e630c96-87ba-44a5-9fd9-c714080a6601">


Known issue: there seems to be extra tabs added to the beginning of the file. Trim() does not remove the extra spaces as they are added in the html. I will be looking into this shortly, I just want to get this out before the demo